### PR TITLE
Change target framework to .NET Standard 2.0

### DIFF
--- a/GoPay.net-sdk/GoPay.net-sdk.csproj
+++ b/GoPay.net-sdk/GoPay.net-sdk.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>gopay_dotnet_standard_api</RootNamespace>
   </PropertyGroup>
 

--- a/Package.nuspec
+++ b/Package.nuspec
@@ -23,7 +23,7 @@
 
 	</metadata>
 	<files>
-        <file src="GoPay.net-sdk\bin\Release\netstandard2.0\GoPay.net-sdk.dll" target="lib\netstandard2.0\GoPay.net-sdk.dll" />
+		<file src="GoPay.net-sdk\bin\Release\netstandard2.0\GoPay.net-sdk.dll" target="lib\netstandard2.0\GoPay.net-sdk.dll" />
 		<file src="./icon.png" target="images\" />
 	</files>
 </package>

--- a/Package.nuspec
+++ b/Package.nuspec
@@ -9,19 +9,21 @@
 		<projectUrl>https://github.com/gopaycommunity/gopay-dotnet-api</projectUrl>
 		<icon>images/icon.png</icon>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
-		<description>GoPay .NET 5</description>
+		<description>GoPay .NET sdk</description>
 		<releaseNotes>Added apple pay, updated supported languages, updated newtonsoft.json</releaseNotes>
 		<copyright>Copyright 2020</copyright>
 		<tags>GoPay Platebni brana</tags>
 		<dependencies>
-			<dependency id="Newtonsoft.Json" version="12.0.3" />
-			<dependency id="RestSharp" version="106.11.7"/>
-			<dependency id="RestSharp.Serializers.NewtonsoftJson" version="106.11.7"/>
+			<group targetFramework=".NETStandard2.0">
+				<dependency id="Newtonsoft.Json" version="12.0.3" />
+				<dependency id="RestSharp" version="106.11.7"/>
+				<dependency id="RestSharp.Serializers.NewtonsoftJson" version="106.11.7"/>
+			</group>
 		</dependencies>
 
 	</metadata>
 	<files>
-		<file src="GoPay.net-sdk\bin\Release\netstandard2.1\*.dll" target="lib\netstandard2.1" />
+        <file src="GoPay.net-sdk\bin\Release\netstandard2.0\GoPay.net-sdk.dll" target="lib\netstandard2.0\GoPay.net-sdk.dll" />
 		<file src="./icon.png" target="images\" />
 	</files>
 </package>

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Detailed guide: [https://doc.gopay.com](https://doc.gopay.com)
 
 # Requirements
 
- - .NET 4.5+
+ - .NET Standard 2.0
 
 # NuGet #
 


### PR DESCRIPTION
Switch required target framework from .NET Standard 2.1 to .NET Standard 2.1 is only compatible with .NET Core 3.0+/.NET 5+ and there's no .NET Framework that supports it. .NET Standard 2.0 is supported by .NET Framework 4.6.1+.